### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,7 +48,7 @@ else:
 display.start()
 
 if args.display_backend == 'vnc':
-	os.system('/usr/bin/fluxbox -display :%s &' % display.display)
+	os.system('/usr/bin/fluxbox -display :{0!s} &'.format(display.display))
 	
 # ---
 # ---
@@ -78,7 +78,7 @@ mimes = [
 	'text/json'
 ]
 
-mimes += ['data:%s' % mime for mime in mimes]
+mimes += ['data:{0!s}'.format(mime) for mime in mimes]
 
 # ---
 # ---


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:secapps-driver?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:secapps-driver?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
